### PR TITLE
Fix an issue where an SVG file would be parsed by PHP.

### DIFF
--- a/header.php
+++ b/header.php
@@ -34,5 +34,5 @@
 	<?php
 		// SVG Sprite for symbols. Make sure this is `display: none`!
 		// https://css-tricks.com/svg-sprites-use-better-icon-fonts/#article-header-id-1
-		include_once(get_stylesheet_directory() . '/assets/images/sprites/symbols.svg');
+		echo file_get_contents(get_stylesheet_directory() . '/assets/images/sprites/symbols.svg');
 	?>

--- a/header.php
+++ b/header.php
@@ -34,5 +34,5 @@
 	<?php
 		// SVG Sprite for symbols. Make sure this is `display: none`!
 		// https://css-tricks.com/svg-sprites-use-better-icon-fonts/#article-header-id-1
-		echo file_get_contents(get_stylesheet_directory() . '/assets/images/sprites/symbols.svg');
+		readfile(get_stylesheet_directory() . '/assets/images/sprites/symbols.svg');
 	?>


### PR DESCRIPTION
The use of `include_once()` with an XML file beginning with `<?` causes a 500 error when the server interprets this as PHP.

This fix swaps `include_once` for echoing the file's contents which is the desired result.

The error on a server supporting short tags:

```
PHP Parse error:  syntax error, unexpected 'version' (T_STRING) in /var/www/vhosts/project-name/wp-content/themes/project-name/assets/images/sprites/symbols.svg on line 1
```
