### PR TITLE
Update force-download.php

### DIFF
--- a/functions/site/force-download.php
+++ b/functions/site/force-download.php
@@ -142,8 +142,9 @@
 				case "htm"  :
 				case "html" :
 				case "txt"  : die("<b>Cannot be used for ". $file_extension ." files!</b>"); break;
-
-				default     : $ctype="application/force-download";
+				
+				default     : die("<b> Not authorized.</b>");
+				//default     : $ctype="application/force-download";
 			}
 
 			header( "Pragma: public" );


### PR DESCRIPTION
Imagine if someone type `http://url.to.website/force-download.php?force-download=true&file=wp-content/../../../../../../../etc/passwd`, the script will respond by sending us the content of `/etc/passwd`.
Also `http://url.to.website/force-download.php?force-download=true&file=wp-content/../.htaccess`
And also `http://url.to.website/force-download.php?force-download=true&file=wp-content/../../.htpasswd`
By this way we will get binnaries (this lead to discovre there version) of the server, and configurations files.
So its important to exit if the file extension do not match those in each case of switch.
